### PR TITLE
Update ArbPlayer component: Modify baseURI construction to remove the…

### DIFF
--- a/src/components/arb-player.tsx
+++ b/src/components/arb-player.tsx
@@ -42,8 +42,9 @@ const ArbPlayer: React.FC<ArbPlayerProps> = ({
 
     // Build proxied URL
     const raw = env("NEXT_PUBLIC_PROXY_URL") || "";
-    const baseURI = raw.replace(/\/+$/, "") + "/m3u8-proxy";
+    const baseURI = raw.replace(/\/+$/, ""); // NO /m3u8-proxy
     const proxiedSrc = `${baseURI}?url=${encodeURIComponent(src)}&referer=${encodeURIComponent(referer)}`;
+    
 
     // Initialize Artplayer without HLS-control plugin yet
     const art = new Artplayer({


### PR DESCRIPTION
… hardcoded '/m3u8-proxy' path, ensuring it uses the raw proxy URL directly for improved flexibility.