### PR TITLE
Fix typo in Traefik routing rule for proxy service in docker-compose.…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     labels:
       - "traefik.enable=true"
       - >
-        traefik.http.routers.proxy.rule=Host(`4rbanime.fun`, `4rabanime.com`)
+        traefik.http.routers.proxy.rule=Host(`4rabanime.fun`, `4rbanime.com`)
         && PathPrefix(`/m3u8-proxy`)
       - "traefik.http.routers.proxy.entrypoints=websecure"
       - "traefik.http.routers.proxy.tls=true"
@@ -27,7 +27,6 @@ services:
       - "traefik.http.services.proxy.loadbalancer.server.port=4040"
       - "traefik.http.middlewares.strip-m3u8-prefix.stripprefix.prefixes=/m3u8-proxy"
       - "traefik.http.routers.proxy.middlewares=strip-m3u8-prefix"
-
 
   4rb-anime:
     build:


### PR DESCRIPTION
…yml, correcting host entry from `4rbanime.fun` to `4rabanime.fun` for accurate routing.