### PR TITLE
Fix proxied URL construction in ArbPlayer: Ensure correct path for m3…

### DIFF
--- a/src/components/arb-player.tsx
+++ b/src/components/arb-player.tsx
@@ -42,10 +42,11 @@ const ArbPlayer: React.FC<ArbPlayerProps> = ({
 
     // Build proxied URL
     const raw = env("NEXT_PUBLIC_PROXY_URL") || "";
-    const baseURI = raw.replace(/\/+$/, "");
-    const proxiedSrc = `${baseURI}?url=${encodeURIComponent(
-      src
-    )}&referer=${encodeURIComponent(referer)}`;
+const baseURI = raw.replace(/\/+$/, "");
+const proxiedSrc = `${baseURI}/m3u8-proxy?url=${encodeURIComponent(
+  src
+)}&referer=${encodeURIComponent(referer)}`;
+
 
     // Initialize Artplayer without HLS-control plugin yet
     const art = new Artplayer({


### PR DESCRIPTION
…u8-proxy in URL building for improved media playback.